### PR TITLE
Fix Spelling Mistake in Error Message

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ if(PROJECT_IS_TOP_LEVEL OR TEST_INSTALLED_VERSION)
   find_package(myproject CONFIG REQUIRED) # for intro, project_options, ...
 
   if(NOT TARGET myproject::project_options)
-    message(FATAL_ERROR "Requiered config package not found!")
+    message(FATAL_ERROR "Required config package not found!")
     return() # be strictly paranoid for Template Janitor github action! CK
   endif()
 endif()


### PR DESCRIPTION
This PR fixes a spelling in error in the tests cmakelists file when project options are missing.