### PR TITLE
optimize_dependencies by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.16...3.23)
 # that tooling and projects use the same version
 set(CMAKE_CXX_STANDARD 20)
 
+# Improve build parallelism of non-generated C, CXX 
+set(CMAKE_OPTIMIZE_DEPENDENCIES ON)
+
 # strongly encouraged to enable this globally to avoid conflicts between
 # -Wpedantic being enabled and -std=c++20 and -std=gnu++20 for example
 # when compiling with PCH enabled


### PR DESCRIPTION
This will improve build parallelism significantly, but at the cost that cmake must be aware of generated srcs.  This is automatic for e.g. configure file, protobuf, etc.   However if you use e.g. exec_program(generate_sources.py), then the targets which depend on the target with these sources must be marked as dependent.